### PR TITLE
Add CODEOWNERS and update Dependabot config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+ # Global ownership - all files default to the repository owner
+* @doraemon0905

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,11 +36,6 @@ updates:
     allow:
       - dependency-type: "direct"
       - dependency-type: "indirect"
-    # Auto-merge configuration for patch updates
-    assignees:
-      - "@doraemon0905"
-    reviewers:
-      - "@doraemon0905"
     # Add commit message prefix
     commit-message:
       prefix: "deps"


### PR DESCRIPTION
Establishes global ownership for repository files by adding a CODEOWNERS file. Simplifies Dependabot configuration by removing auto-merge assignee and reviewer settings, streamlining the update process.